### PR TITLE
Added early/late indicator. fixes #6

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -398,7 +398,7 @@ local Overrides = {
 			-- so we have to use %.3f and remove trailing zeroes with gsub and a bit of magic (regexp)
 			local t = {}
 			for k, v in pairs(range(first, last, step)) do
-				earlylate = " (notes come "..( v > 0 and "earlier)" or "later)" )
+				earlylate = " (notes "..( v > 0 and "earlier)" or "later)" )
 				number = string.format("%.3f", v):gsub("%.?0+$", "")
 				-- 0 is not actually zero so we have to look for it after formatting
 				if number == "0" then earlylate = "" end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -398,6 +398,20 @@ local Overrides = {
 			-- so we have to use %.3f and remove trailing zeroes with gsub and a bit of magic (regexp)
 			local t = {}
 			for k, v in pairs(range(first, last, step)) do
+				earlylate = " (notes come "..( v > 0 and "earlier)" or "later)" )
+				number = string.format("%.3f", v):gsub("%.?0+$", "")
+				-- 0 is not actually zero so we have to look for it after formatting
+				if number == "0" then earlylate = "" end
+				t[k] = number..earlylate
+			end
+			return t
+		end,
+		Values = function() local first	= -0.15
+			local last 	= 0.15
+			local step 	= 0.001
+
+			local t = {}
+			for k, v in pairs(range(first, last, step)) do
 				t[k] = string.format("%.3f", v):gsub("%.?0+$", "")
 			end
 			return t
@@ -405,13 +419,13 @@ local Overrides = {
 		LoadSelections = function(self,list)
                         if not GAMESTATE:Env()["NewOffset"] then GAMESTATE:Env()["NewOffset"] = string.format( "%.3f", PREFSMAN:GetPreference( "GlobalOffsetSeconds" ) ) end 
                         local envset = string.format("%.3f",GAMESTATE:Env()["NewOffset"])
-			local i = FindInTable(envset, self.Choices) or math.round(#self.Choices/2)
+			local i = FindInTable(envset, self.Values) or math.round(#self.Values/2)
                         list[i] = true
 			return list
                 end,
                 SaveSelections = function(self,list,player)
                         if not GAMESTATE:Env()["OriginalOffset"] then GAMESTATE:Env()["OriginalOffset"] = string.format( "%.3f", PREFSMAN:GetPreference( "GlobalOffsetSeconds" ) ) end 
-                        for i,_ in ipairs(self.Choices) do
+                        for i,_ in ipairs(self.Values) do
                                 if list[i] == true then
                                         GAMESTATE:Env()["NewOffset"] = _ 
                                 end


### PR DESCRIPTION
Added a text indication of how positive/negative values of the offset affect the timing of the arrows in the option row (right after the value)
![image](https://user-images.githubusercontent.com/19793145/76032646-a2113500-5f3a-11ea-9ea2-305db8cfe004.png)
![image](https://user-images.githubusercontent.com/19793145/76032705-c1a85d80-5f3a-11ea-8c42-c18c9cea8204.png)
![image](https://user-images.githubusercontent.com/19793145/76032674-b0f7e780-5f3a-11ea-81ca-9ebf98841af1.png)
