### PR TITLE
Deleted obsolete use of GAMESTATE:Env()["OriginalOffset"]

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -424,7 +424,6 @@ local Overrides = {
 			return list
                 end,
                 SaveSelections = function(self,list,player)
-                        if not GAMESTATE:Env()["OriginalOffset"] then GAMESTATE:Env()["OriginalOffset"] = string.format( "%.3f", PREFSMAN:GetPreference( "GlobalOffsetSeconds" ) ) end 
                         for i,_ in ipairs(self.Values) do
                                 if list[i] == true then
                                         GAMESTATE:Env()["NewOffset"] = _ 


### PR DESCRIPTION
This was used to store the global offset set by the operator so that we could recover it after every game. After https://github.com/Sereni/Simply-Love-SM5/commit/30f9f08bed3d078ed13d5084d33116c1863e80a6 this is no longer needed.