### PR TITLE
Made OneChoiceForAllPlayers and ExportOnChange true for gnGlobalOffset so it behaves similar to MusicRate

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -416,6 +416,8 @@ local Overrides = {
 			end
 			return t
 		end,
+		ExportOnChange = true,
+		OneChoiceForAllPlayers = true,
 		LoadSelections = function(self,list)
                         if not GAMESTATE:Env()["NewOffset"] then GAMESTATE:Env()["NewOffset"] = string.format( "%.3f", PREFSMAN:GetPreference( "GlobalOffsetSeconds" ) ) end 
                         local envset = string.format("%.3f",GAMESTATE:Env()["NewOffset"])


### PR DESCRIPTION
OneChoiceForAllPlayers was necessary and ExportOnChange is just convenient to avoid accidentaly not choosing the value.