### PR TITLE
Display custom global offset on ScreenSelectMusic

### DIFF
--- a/Graphics/ScreenSelectMusic header.lua
+++ b/Graphics/ScreenSelectMusic header.lua
@@ -76,4 +76,19 @@ local t = Def.ActorFrame{
 	}
 }
 
+t[#t+1] = LoadFont("_wendy small")..{
+	Name="CustomGlobalOffset",
+	InitCommand=function(self)
+		self:diffusealpha(0):zoom( WideScale(0.5,0.6)):xy(_screen.w-170, 15):halign(1)
+	end,
+	OnCommand=function(self)
+		self:settext(GetGlobalOffsetDiffString())
+			:sleep(0.1):decelerate(0.33):diffusealpha(1)
+	end,
+	-- FIXME: Changing global offset via F11/12 will not trigger an update.
+	GlobalOffsetChangedMessageCommand=function(self)
+		self:settext(GetGlobalOffsetDiffString())
+	end
+}
+
 return t

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -653,7 +653,7 @@ end
 -- DefaultGlobalOffset = 0.069
 -- returns: 0.066
 GlobalOffsetAbsoluteValueFromDiffString = function(diffString)
-  local diffSeconds = tonumber(diffString.gsub(" ms", "")) / 1000
+  local diffSeconds = tonumber(diffString:gsub(" ms", ""), 10) / 1000
 	local defaultOffset = ThemePrefs.Get("DefaultGlobalOffsetSeconds")
-	return defaultOffset + diffSeconds 
+	return defaultOffset + diffSeconds
 end

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -627,3 +627,33 @@ GetDifficultyIndex = function(difficulty)
 	local difficulty_index = Difficulty:Reverse()[difficulty]
 	if type(difficulty_index) == "number" then return (difficulty_index + 1) end
 end
+
+-- -----------------------------------------------------------------------
+-- Get the difference between default global offset stored in ThemePrefs, and the
+-- current global offset, formatted as "+/- X ms".
+-- Example:
+-- DefaultGlobalOffset = 0.069
+-- Current GlobalOffset = 0.066
+-- returns: "-3 ms"
+GetGlobalOffsetDiffString = function()
+  local defaultOffset = ThemePrefs.Get("DefaultGlobalOffsetSeconds")
+	local currentOffset = PREFSMAN:GetPreference("GlobalOffsetSeconds")
+	local diffMs = (defaultOffset - currentOffset) * 1000
+	if (string.format("%.0f", diffMs) == "0") then return "" end
+	local formattedDiff = string.format("%.0f ms", diffMs)
+	if (diffMs > 0) then formattedDiff = "+" .. formattedDiff end
+	return formattedDiff
+end
+
+-- -----------------------------------------------------------------------
+-- Parse the global offset diff string in the format "+/- X ms", and return the
+-- absolute value it represents.
+-- Example:
+-- diffString = "-3 ms"
+-- DefaultGlobalOffset = 0.069
+-- returns: 0.066
+GlobalOffsetAbsoluteValueFromDiffString = function(diffString)
+  local diffSeconds = tonumber(diffString.gsub(" ms", "")) / 1000
+	local defaultOffset = ThemePrefs.Get("DefaultGlobalOffsetSeconds")
+	return defaultOffset + diffSeconds 
+end

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -644,16 +644,3 @@ GetGlobalOffsetDiffString = function()
 	if (diffMs > 0) then formattedDiff = "+" .. formattedDiff end
 	return formattedDiff
 end
-
--- -----------------------------------------------------------------------
--- Parse the global offset diff string in the format "+/- X ms", and return the
--- absolute value it represents.
--- Example:
--- diffString = "-3 ms"
--- DefaultGlobalOffset = 0.069
--- returns: 0.066
-GlobalOffsetAbsoluteValueFromDiffString = function(diffString)
-  local diffSeconds = tonumber(diffString:gsub(" ms", ""), 10) / 1000
-	local defaultOffset = ThemePrefs.Get("DefaultGlobalOffsetSeconds")
-	return defaultOffset + diffSeconds
-end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -417,6 +417,7 @@ local Overrides = {
                                 end
                         end
 			PREFSMAN:SetPreference( "GlobalOffsetSeconds", GAMESTATE:Env()["NewOffset"] )
+			MESSAGEMAN:Broadcast("GlobalOffsetChanged")
                 end,
         },
 	-------------------------------------------------------------------------


### PR DESCRIPTION
If global offset was changed via Advanced options, display the difference on the screen.
Also add formatting utils that convert offset to the diff string and 
back.

<img width="1080" alt="offset diff displayed in header" src="https://user-images.githubusercontent.com/4284741/76140115-f9082e80-604e-11ea-9aa0-9d555dd10b2a.png">
